### PR TITLE
98 use sparse matrices in milp solver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ cython_debug/
 
 .vscode/
 /*.ipynb
+.DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "sigmaepsilon.math"
-version = "2.2.2"
+version = "2.3.0"
 description = "A Python Library for Applied Mathematics in Physical Sciences."
 classifiers=[  # https://pypi.org/classifiers/
         "Development Status :: 5 - Production/Stable",

--- a/src/sigmaepsilon/math/optimize/bga.py
+++ b/src/sigmaepsilon/math/optimize/bga.py
@@ -45,9 +45,9 @@ class BinaryGeneticAlgorithm(GeneticAlgorithm):
         The minimum number of iterations. Default is 100.
     elitism: float or int, Optional
         Determines the portion of the population designated as elite, which automatically survives
-        to the next generation. If less than or equal to 1, it specifies a fraction of the population. 
-        If greater than 1, it indicates the exact number of individuals to be selected as elite. 
-        The default value of 1 assures that the reigning champion is always preserved. To turn this off, 
+        to the next generation. If less than or equal to 1, it specifies a fraction of the population.
+        If greater than 1, it indicates the exact number of individuals to be selected as elite.
+        The default value of 1 assures that the reigning champion is always preserved. To turn this off,
         det the value to None. Default is 1.
     ftol: float, Optional
         Torelance for floating point operations. Default is 1e-12.
@@ -165,7 +165,9 @@ class BinaryGeneticAlgorithm(GeneticAlgorithm):
         p = np.random.rand(self.dim * self.length)
         return np.where(p > self.p_m, child, 1 - child)
 
-    def select(self, genotypes: ndarray | None = None, phenotypes: ndarray | None = None) -> ndarray:
+    def select(
+        self, genotypes: ndarray | None = None, phenotypes: ndarray | None = None
+    ) -> ndarray:
         """
         Organizes a tournament and returns the genotypes of the winners.
 

--- a/src/sigmaepsilon/math/optimize/ga.py
+++ b/src/sigmaepsilon/math/optimize/ga.py
@@ -74,6 +74,7 @@ class Genom(BaseModel):
     @property
     def fittness(self) -> float:  # pragma: no cover
         import warnings
+
         warnings.warn(
             "'fittness' was a typo and is deprecated; it will be removed in a future version. Use 'fitness' instead.",
             DeprecationWarning,
@@ -276,7 +277,6 @@ class GeneticAlgorithm:
                 self._phenotypes = self.decode(genotypes)
         return self._phenotypes
 
-
     @property
     def fitness(self) -> ndarray:
         """
@@ -290,8 +290,9 @@ class GeneticAlgorithm:
         return self._fitness
 
     @property
-    def fittness(self) -> ndarray: # pragma: no cover
+    def fittness(self) -> ndarray:  # pragma: no cover
         import warnings
+
         warnings.warn(
             "'fittness' was a typo and is deprecated; it will be removed in a future version. Use 'fitness' instead.",
             DeprecationWarning,
@@ -655,9 +656,7 @@ class GeneticAlgorithm:
         ...
 
     @abstractmethod
-    def select(
-        self, genotypes: ndarray, phenotypes: ndarray
-    ) -> ndarray:
+    def select(self, genotypes: ndarray, phenotypes: ndarray) -> ndarray:
         """
         Ought to implement some kind of selection mechanism, e.g., a roulette wheel,
         tournament, or other. Both `genotypes` and `phenotypes` must be provided.

--- a/src/sigmaepsilon/math/optimize/lp.py
+++ b/src/sigmaepsilon/math/optimize/lp.py
@@ -211,7 +211,7 @@ class LinearProgrammingProblem:
                 A_eq_cols = []
             else:
                 A_eq = np.zeros((n_eq, n_x))
-            
+
             b_eq = np.zeros((n_eq,))
             equalities: Iterable[Equality] = filter(
                 lambda c: isinstance(c, Equality), self.constraints
@@ -227,11 +227,13 @@ class LinearProgrammingProblem:
                             A_eq_cols.append(j)
                 else:
                     A_eq[i] = [coeffs[x_] for x_ in self.variables]
-                    
+
                 b_eq[i] = -eq(x_zero)
-            
+
             if self._sparsify:
-                A_eq = sparse.csr_matrix((A_eq_data, (A_eq_rows, A_eq_cols)), shape=(n_eq, n_x), dtype=float)
+                A_eq = sparse.csr_matrix(
+                    (A_eq_data, (A_eq_rows, A_eq_cols)), shape=(n_eq, n_x), dtype=float
+                )
                 del A_eq_data, A_eq_rows, A_eq_cols
 
         if n_ieq > 0:
@@ -241,14 +243,14 @@ class LinearProgrammingProblem:
                 A_ub_cols = []
             else:
                 A_ub = np.zeros((n_ieq, n_x))
-                
+
             b_ub = np.zeros((n_ieq,))
             inequalities: Iterable[InEquality] = filter(
                 lambda c: isinstance(c, InEquality), self.constraints
             )
             for i, ieq in enumerate(inequalities):
                 coeffs = ieq.linear_coefficients(normalize=True)
-                
+
                 A_ub_multiplier = 1
                 b_ub_multiplier = 1
                 b_ub_adjustment = 0.0
@@ -261,7 +263,7 @@ class LinearProgrammingProblem:
                     b_ub_adjustment = -SMALLNUM
                 elif ieq.op == Relations.lt:
                     b_ub_adjustment = -SMALLNUM
-                
+
                 if self._sparsify:
                     for j, x_ in enumerate(self.variables):
                         val = coeffs[x_] * A_ub_multiplier
@@ -271,13 +273,15 @@ class LinearProgrammingProblem:
                             A_ub_cols.append(j)
                 else:
                     A_ub[i] = [coeffs[x_] * A_ub_multiplier for x_ in self.variables]
-                
+
                 b_ub[i] = -ieq(x_zero) * b_ub_multiplier + b_ub_adjustment
-                
+
             if self._sparsify:
-                A_ub = sparse.csr_matrix((A_ub_data, (A_ub_rows, A_ub_cols)), shape=(n_ieq, n_x), dtype=float)
+                A_ub = sparse.csr_matrix(
+                    (A_ub_data, (A_ub_rows, A_ub_cols)), shape=(n_ieq, n_x), dtype=float
+                )
                 del A_ub_data, A_ub_rows, A_ub_cols
-                    
+
         integrality = self.integrality
         if integrality is None:
             is_int = [v.is_integer for v in self.variables]

--- a/tests/test_lp_gt_lt_constraints.py
+++ b/tests/test_lp_gt_lt_constraints.py
@@ -1,0 +1,30 @@
+import sympy as sy
+from sigmaepsilon.math.optimize.lp import LinearProgrammingProblem
+from sigmaepsilon.math.function import Function, InEquality
+from sigmaepsilon.math.function.relation import Relations
+
+
+def make_problem_with_ineq(op):
+    x, y = sy.symbols("x y")
+    obj = Function(x + y, variables=[x, y])
+    # The constraint is x + y op 1
+    ineq = InEquality(x + y - 1, op=op, variables=[x, y])
+    bounds = [(None, None), (None, None)]
+    return LinearProgrammingProblem(
+        obj, [ineq], variables=[x, y], bounds=bounds, sparsify=False
+    )
+
+
+def test_lp_gt_constraint():
+    # Covers the Relations.gt branch
+    problem = make_problem_with_ineq(Relations.gt)
+    # Should not raise, and should produce a valid scipy linprog call
+    res = problem.solve()
+    assert hasattr(res, "success")
+
+
+def test_lp_lt_constraint():
+    # Covers the Relations.lt branch
+    problem = make_problem_with_ineq(Relations.lt)
+    res = problem.solve()
+    assert hasattr(res, "success")

--- a/tests/test_lp_integrality_infer.py
+++ b/tests/test_lp_integrality_infer.py
@@ -1,0 +1,23 @@
+import sympy as sy
+import numpy as np
+from sigmaepsilon.math.optimize.lp import LinearProgrammingProblem
+from sigmaepsilon.math.function import Function, Relation
+from sigmaepsilon.math.function.relation import Relations
+
+
+def test_lp_integrality_inferred_from_symbolic_vars():
+    # x is integer, y is not
+    x = sy.symbols("x", integer=True)
+    y = sy.symbols("y")
+    obj = Function(x + y, variables=[x, y])
+    # Simple constraint: x + y >= 1
+    ineq = Relation(x + y - 1, op=Relations.ge, variables=[x, y])
+    bounds = [(None, None), (None, None)]
+    # Do not pass integrality, so it is inferred from variable assumptions
+    problem = LinearProgrammingProblem(
+        obj, [ineq], variables=[x, y], bounds=bounds, sparsify=False
+    )
+    _, kwargs = problem._to_scipy()
+    # The integrality array should be [1, 0] (x is integer, y is not)
+    assert "integrality" in kwargs
+    assert np.array_equal(kwargs["integrality"], np.array([1, 0]))


### PR DESCRIPTION
The LPP solver now uses sparse matrices by default. The behaviour can be controlled through the `sparsify` parameter when initializing the solver.